### PR TITLE
sepolicy: patch for Nougat

### DIFF
--- a/sepolicy/autokd.te
+++ b/sepolicy/autokd.te
@@ -49,3 +49,6 @@ allow autokd userdata_block_device:blk_file { open read write };
 allow autokd nvdata_file:dir {search read write getattr add_name remove_name };
 allow autokd nvdata_file:file { read write getattr create open setattr };
 
+# for Nougat
+allow autokd sysfs:file { write read open };
+

--- a/sepolicy/batterywarning.te
+++ b/sepolicy/batterywarning.te
@@ -38,3 +38,6 @@ allow batterywarning system_server:binder call;
 # Purpose : allow battery warning check AMS service status
 allow batterywarning activity_service:service_manager find;
 
+# Nougat
+allow batterywarning sysfs:file r_file_perms;
+

--- a/sepolicy/ccci_fsd.te
+++ b/sepolicy/ccci_fsd.te
@@ -54,3 +54,7 @@ allow ccci_fsd nvdata_device:blk_file { read write open ioctl };
 allow ccci_fsd rawfs:dir create_dir_perms;
 allow ccci_fsd rawfs:file create_file_perms;
 
+# for Nougat
+allow ccci_fsd sysfs:file r_file_perms;
+allow ccci_fsd mtk_md_prop:file r_file_perms;
+

--- a/sepolicy/ccci_mdinit.te
+++ b/sepolicy/ccci_mdinit.te
@@ -102,3 +102,6 @@ allow ccci_mdinit mtd_device:chr_file { read write open };
 # Purpose : for device bring up, not to block early migration/sanity
 allow ccci_mdinit proc_lk_env:file rw_file_perms;
 
+# Nougat
+allow ccci_mdinit sysfs:file { write read open };
+

--- a/sepolicy/emdlogger.te
+++ b/sepolicy/emdlogger.te
@@ -95,3 +95,9 @@ allow emdlogger mnt_user_file:lnk_file read;
 #allow emdlogger storage_file:dir search;
 allow emdlogger storage_file:lnk_file read;
 
+# Nougat
+allow emdlogger persist_mtklog_prop:file r_file_perms;
+allow emdlogger proc:file r_file_perms;
+allow emdlogger sysfs:file { read open };
+allow emdlogger rootfs:file r_file_perms;
+

--- a/sepolicy/mtk_6620_launcher.te
+++ b/sepolicy/mtk_6620_launcher.te
@@ -27,4 +27,8 @@ allow mtk_6620_launcher property_socket:sock_file write;
 allow mtk_6620_launcher stpwmt_device:chr_file { read write ioctl open };
 allow mtk_6620_launcher devpts:chr_file { read write };
 
+# for Nougat
+allow mtk_6620_launcher wmt_prop:file r_file_perms;
+
 init_daemon_domain(mtk_6620_launcher)
+

--- a/sepolicy/mtkrild.te
+++ b/sepolicy/mtkrild.te
@@ -93,3 +93,6 @@ allow mtkrild socket_device:sock_file write;
 allow mtkrild mtkmal:unix_stream_socket connectto;
 allow mtkrild mal_mfi_socket:sock_file write;
 
+# Nougat
+allow mtkrild proc:file { open write };
+

--- a/sepolicy/ppl_agent.te
+++ b/sepolicy/ppl_agent.te
@@ -63,3 +63,6 @@ allow ppl_agent nvram_device:chr_file { read write ioctl open };
 allow ppl_agent mtd_device:dir search;
 allow ppl_agent mtd_device:chr_file { read write open };
 
+# Nougat
+allow ppl_agent proc:file r_file_perms;
+

--- a/sepolicy/tune2fs.te
+++ b/sepolicy/tune2fs.te
@@ -19,3 +19,7 @@ init_daemon_domain(tune2fs)
 allow tune2fs userdata_block_device:blk_file rw_file_perms;
 allow tune2fs block_device:dir search;
 
+# for Nougat
+allow tune2fs proc:file r_file_perms;
+
+

--- a/sepolicy/wifi2agps.te
+++ b/sepolicy/wifi2agps.te
@@ -25,3 +25,6 @@ allow wifi2agps self:netlink_socket {write getattr setopt read bind create};
 allow wifi2agps self:udp_socket { create ioctl };
 allow wifi2agps agpsd_data_file:dir search;
 
+# for Nougat
+allow wifi2agps proc_net:file r_file_perms;
+


### PR DESCRIPTION
The lib_driver_cmd_mt66xx driver folder is missing would you like to add it?

Link for the file : https://drive.google.com/open?id=0B-3F2QtO04kHcWp2bm52S3Y2MVU
( if you want to analyse)
